### PR TITLE
feature/request-body-handling: Configurable request body

### DIFF
--- a/Sources/SwiftNetKit/BaseRequest.swift
+++ b/Sources/SwiftNetKit/BaseRequest.swift
@@ -54,6 +54,10 @@ public struct BaseRequest<Response: Decodable>: RequestProtocol {
             case .jsonEncodable(let encodable):
                 let jsonData = try? JSONEncoder().encode(encodable)
                 urlRequest.httpBody = jsonData
+                
+                if headers?["Content-Type"] == nil {
+                    urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                }
             }
         }
         

--- a/Sources/SwiftNetKit/BaseRequest.swift
+++ b/Sources/SwiftNetKit/BaseRequest.swift
@@ -14,14 +14,14 @@ public struct BaseRequest<Response: Decodable>: RequestProtocol {
     let method: MethodType
     let parameters: [String : Any]?
     let headers: [String : String]?
-    let body: Data?
+    let body: RequestBody?
     
     init(
         url: URL,
         method: MethodType,
         parameters: [String : Any]? = nil,
         headers: [String : String]? = nil,
-        body: Data? = nil
+        body: RequestBody? = nil
     ) {
         self.url = url
         self.method = method
@@ -46,7 +46,15 @@ public struct BaseRequest<Response: Decodable>: RequestProtocol {
         urlRequest.allHTTPHeaderFields = self.headers
         
         if let body = self.body {
-            urlRequest.httpBody = body
+            switch body {
+            case .data(let data):
+                urlRequest.httpBody = data
+            case .string(let string):
+                urlRequest.httpBody = string.data(using: .utf8)
+            case .jsonEncodable(let encodable):
+                let jsonData = try? JSONEncoder().encode(encodable)
+                urlRequest.httpBody = jsonData
+            }
         }
         
         return urlRequest

--- a/Sources/SwiftNetKit/Models/RequestBody.swift
+++ b/Sources/SwiftNetKit/Models/RequestBody.swift
@@ -1,0 +1,14 @@
+//
+//  RequestBody.swift
+//
+//
+//  Created by Sam Gilmore on 7/18/24.
+//
+
+import Foundation
+
+public enum RequestBody {
+    case jsonEncodable(Encodable)
+    case data(Data)
+    case string(String)
+}

--- a/Sources/SwiftNetKit/Protocols/RequestProtocol.swift
+++ b/Sources/SwiftNetKit/Protocols/RequestProtocol.swift
@@ -14,7 +14,7 @@ protocol RequestProtocol {
     var method: MethodType { get }
     var parameters: [String: Any]? { get }
     var headers: [String: String]? { get }
-    var body: Data? { get }
+    var body: RequestBody? { get }
     
     func buildURLRequest() -> URLRequest
 }


### PR DESCRIPTION
## Description

This PR allows the user to easily set the body of a request as either a String, a Data object, or a Swift model of their choosing that conforms to Encodable.