### PR TITLE
epic/caching: Implement Caching Configuration

### DIFF
--- a/Sources/SwiftNetKit/BaseRequest.swift
+++ b/Sources/SwiftNetKit/BaseRequest.swift
@@ -15,18 +15,21 @@ public struct BaseRequest<Response: Decodable>: RequestProtocol {
     let parameters: [String : Any]?
     let headers: [String : String]?
     let body: RequestBody?
+    let cacheConfiguration: CacheConfiguration?
     
     init(
         url: URL,
         method: MethodType,
         parameters: [String : Any]? = nil,
         headers: [String : String]? = nil,
-        body: RequestBody? = nil
+        body: RequestBody? = nil,
+        cacheConfiguration: CacheConfiguration? = nil
     ) {
         self.url = url
         self.method = method
         self.parameters = parameters
         self.headers = headers
         self.body = body
+        self.cacheConfiguration = cacheConfiguration
     }
 }

--- a/Sources/SwiftNetKit/CacheConfiguration.swift
+++ b/Sources/SwiftNetKit/CacheConfiguration.swift
@@ -1,0 +1,25 @@
+//
+//  CacheConfiguration.swift
+//
+//
+//  Created by Sam Gilmore on 7/19/24.
+//
+
+import Foundation
+
+public struct CacheConfiguration {
+    var memoryCapacity: Int
+    var diskCapacity: Int
+    var diskPath: String?
+    var cachePolicy: URLRequest.CachePolicy
+    
+    public init(memoryCapacity: Int = 20 * 1024 * 1024, // 20 MB
+                diskCapacity: Int = 100 * 1024 * 1024, // 100 MB
+                diskPath: String? = nil,
+                cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy) {
+        self.memoryCapacity = memoryCapacity
+        self.diskCapacity = diskCapacity
+        self.diskPath = diskPath
+        self.cachePolicy = cachePolicy
+    }
+}

--- a/Sources/SwiftNetKit/Protocols/RequestProtocol.swift
+++ b/Sources/SwiftNetKit/Protocols/RequestProtocol.swift
@@ -15,6 +15,7 @@ protocol RequestProtocol {
     var parameters: [String: Any]? { get }
     var headers: [String: String]? { get }
     var body: RequestBody? { get }
+    var cacheConfiguration: CacheConfiguration? { get }
     
     func buildURLRequest() -> URLRequest
 }
@@ -22,6 +23,8 @@ protocol RequestProtocol {
 extension RequestProtocol {
     func buildURLRequest() -> URLRequest {
         var urlRequest = URLRequest(url: self.url)
+        
+        urlRequest.cachePolicy = self.cacheConfiguration?.cachePolicy ?? .useProtocolCachePolicy
         
         if let parameters = self.parameters {
             let queryItems = parameters.map { key, value in


### PR DESCRIPTION
## Description

This PR allows a user to specify per-request caching configurations such as memory capacity, disk capacity, disk path, and a cache policy that gets applied to the URLSession itself.